### PR TITLE
Eliminar Categoría [1]

### DIFF
--- a/my-app/src/lib/balance-utils.ts
+++ b/my-app/src/lib/balance-utils.ts
@@ -71,3 +71,9 @@ function computeTotal(objects: { category_id: Id; amount: number }[], categoryId
 function formatCategoryList(categoryList: { categoryName: string }[]): string {
 	return categoryList.map(({ categoryName }) => `"${categoryName}"`).join(', ');
 }
+
+export function archivedCategoriesLast(categories: Category[]) {
+	const archived = categories.filter(({ is_archived }) => is_archived);
+	const active = categories.filter(({ is_archived }) => !is_archived);
+	return [...active, ...archived];
+}

--- a/my-app/src/lib/components/CategoryFilter.svelte
+++ b/my-app/src/lib/components/CategoryFilter.svelte
@@ -27,7 +27,7 @@
 			<OwnerOnly {ownerId}>
 				<a
 					class="btn-sm {!active ? 'outline' : ''}"
-					href="{routes.categoryDetails}/{category.id}"
+					href={routes.categoryDetails(category.id)}
 					role="button"
 				>
 					<CssIcon name="pen" size={0.7} />

--- a/my-app/src/lib/components/CategoryFilter.svelte
+++ b/my-app/src/lib/components/CategoryFilter.svelte
@@ -5,17 +5,26 @@
 
 	export let ownerId: Id;
 	export let categories: Category[];
+	export let sortedCategories: Category[];
 	export let filter: Id[];
 
 	function toggleCategoryFilter(categoryId: Id, shouldFilter: boolean) {
 		filter = shouldFilter ? [...filter, categoryId] : filter.filter((id) => id !== categoryId);
 	}
+
+	function sortCategories(categories: Category[]) {
+		const archived = categories.filter(({ is_archived }) => is_archived);
+		const active = categories.filter(({ is_archived }) => !is_archived);
+		return [...active, ...archived];
+	}
+
+	$: sortedCategories = sortCategories(categories);
 </script>
 
 <div>
 	<CssIcon name="tag" />
 	Categorías:
-	{#each categories as category}
+	{#each sortedCategories as category}
 		{@const active = filter.includes(category.id)}
 		{@const activeClass = !active ? 'outline' : ''}
 		{@const archivedClass = category.is_archived ? 'contrast' : ''}

--- a/my-app/src/lib/components/CategoryFilter.svelte
+++ b/my-app/src/lib/components/CategoryFilter.svelte
@@ -17,16 +17,18 @@
 	Categorías:
 	{#each categories as category}
 		{@const active = filter.includes(category.id)}
+		{@const activeClass = !active ? 'outline' : ''}
+		{@const archivedClass = category.is_archived ? 'contrast' : ''}
 		<div style="width: auto; vertical-align: baseline; margin:5px;" role="group">
 			<button
 				on:click={() => toggleCategoryFilter(category.id, !active)}
-				class="btn-sm {!active ? 'outline' : ''}"
+				class="btn-sm {activeClass} {archivedClass}"
 			>
 				{category.name}
 			</button>
 			<OwnerOnly {ownerId}>
 				<a
-					class="btn-sm {!active ? 'outline' : ''}"
+					class="btn-sm {activeClass} {archivedClass}"
 					href={routes.categoryDetails(category.id)}
 					role="button"
 				>

--- a/my-app/src/lib/components/CategoryFilter.svelte
+++ b/my-app/src/lib/components/CategoryFilter.svelte
@@ -6,7 +6,6 @@
 
 	export let ownerId: Id;
 	export let categories: Category[];
-	export let sortedCategories: Category[];
 	export let filter: Id[];
 
 	function toggleCategoryFilter(categoryId: Id, shouldFilter: boolean) {

--- a/my-app/src/lib/components/CategoryFilter.svelte
+++ b/my-app/src/lib/components/CategoryFilter.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { routes } from '$lib';
+	import { archivedCategoriesLast } from '$lib/balance-utils';
 	import CssIcon from './CssIcon.svelte';
 	import OwnerOnly from './OwnerOnly.svelte';
 
@@ -12,13 +13,7 @@
 		filter = shouldFilter ? [...filter, categoryId] : filter.filter((id) => id !== categoryId);
 	}
 
-	function sortCategories(categories: Category[]) {
-		const archived = categories.filter(({ is_archived }) => is_archived);
-		const active = categories.filter(({ is_archived }) => !is_archived);
-		return [...active, ...archived];
-	}
-
-	$: sortedCategories = sortCategories(categories);
+	$: sortedCategories = archivedCategoriesLast(categories);
 </script>
 
 <div>

--- a/my-app/src/lib/index.ts
+++ b/my-app/src/lib/index.ts
@@ -43,7 +43,7 @@ export const routes = {
 	groupMembers: (groupId: Id) => `/groups/${groupId}/members`,
 	groupMovements: (groupId: Id) => `/groups/${groupId}/movements`,
 	// categories
-	categoryDetails: '/categories/details',
+	categoryDetails: (categoryId?: Id) => `/categories/details${categoryId ? `/${categoryId}` : ''}`,
 	// budgets
 	budgetDetails: '/budgets/details',
 	// spendings

--- a/my-app/src/lib/server/api.ts
+++ b/my-app/src/lib/server/api.ts
@@ -125,7 +125,9 @@ export const categoryService = {
 			? put(`category/${data.id}`, data, getAuthHeader(cookies))
 			: post('category', data, getAuthHeader(cookies)),
 	get: (id: Id, cookies: Cookies) => get(`category/${id}`, getAuthHeader(cookies)),
-	list: (groupId: Id, cookies: Cookies) => get(`group/${groupId}/category`, getAuthHeader(cookies))
+	list: (groupId: Id, cookies: Cookies) => get(`group/${groupId}/category`, getAuthHeader(cookies)),
+	archive: (id: Id, cookies: Cookies) => put(`category/${id}/is_archived`, { is_archived: true }, getAuthHeader(cookies)),
+	unarchive: (id: Id, cookies: Cookies) => put(`category/${id}/is_archived`, { is_archived: false }, getAuthHeader(cookies))
 };
 export const inviteService = {
 	get: (token: string, cookies: Cookies) => get(`invite/${token}`, getAuthHeader(cookies)),

--- a/my-app/src/routes/budgets/details/[[id=integer]]/+page.svelte
+++ b/my-app/src/routes/budgets/details/[[id=integer]]/+page.svelte
@@ -33,6 +33,7 @@
 			try {
 				const response = await fetch(`/api/categories?groupId=${groupId}`);
 				categories = await response.json();
+				categories = categories.filter((category) => !category.is_archived);
 				return;
 			} catch {}
 		}

--- a/my-app/src/routes/categories/details/[[id=integer]]/+page.server.ts
+++ b/my-app/src/routes/categories/details/[[id=integer]]/+page.server.ts
@@ -15,7 +15,7 @@ export const load: PageServerLoad = async ({ params, url, cookies }) => {
 };
 
 export const actions: Actions = {
-	default: async ({ cookies, request, params }) => {
+	update: async ({ cookies, request, params }) => {
 		const id = Number(params.id) || 0;
 		const data = await request.formData();
 		const name = data.get('name')?.toString();
@@ -37,5 +37,13 @@ export const actions: Actions = {
 		await categoryService.save(category, cookies);
 
 		redirect(302, routes.groupMovements(group_id));
+	},
+	archive: async ({ cookies, params }) => {
+		const id = Number(params.id) || 0;
+		await categoryService.archive(id, cookies);
+	},
+	unarchive: async ({ cookies, params }) => {
+		const id = Number(params.id) || 0;
+		await categoryService.unarchive(id, cookies);
 	}
 };

--- a/my-app/src/routes/categories/details/[[id=integer]]/+page.svelte
+++ b/my-app/src/routes/categories/details/[[id=integer]]/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-	import { title } from '$lib';
+	import { goto } from '$app/navigation';
+	import { routes, title } from '$lib';
+	import CssIcon from '$lib/components/CssIcon.svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
 
 	const edit = data.category.id !== 0;
+	const isArchived = data.category.is_archived;
 </script>
 
 <svelte:head>
@@ -18,11 +21,11 @@
 <h2>
 	{#if edit}Editando{:else}Creando{/if} Categoría
 </h2>
-<form method="POST">
+<form method="POST" action="?/update">
 	<fieldset>
 		<label>
 			Ingrese un grupo para la categoría
-			<select name="groupId" required value={data.category.group_id}>
+			<select name="groupId" required disabled={isArchived} value={data.category.group_id}>
 				{#each data.groups as group}
 					<option disabled={edit && group.id !== data.category.group_id} value={group.id}
 						>{group.name}</option
@@ -32,7 +35,14 @@
 		</label>
 		<label>
 			Ingrese un nombre para la categoría
-			<input type="text" name="name" placeholder="Nombre" required value={data.category.name} />
+			<input
+				type="text"
+				name="name"
+				placeholder="Nombre"
+				required
+				disabled={isArchived}
+				value={data.category.name}
+			/>
 		</label>
 		<label>
 			Ingrese una descripción para la categoría
@@ -41,14 +51,30 @@
 				name="description"
 				placeholder="Description"
 				required
+				disabled={isArchived}
 				value={data.category.description}
 			/>
 		</label>
 		{#if edit}
-			<button>Editar</button>
+			{#if isArchived}
+				<button class="contrast" formaction="?/unarchive">
+					<CssIcon name="lock-unlock" />
+					Desarchivar
+				</button>
+			{:else}
+				<button>Editar</button>
+				<button class="outline contrast" formaction="?/archive">
+					<CssIcon name="lock" />
+					Archivar
+				</button>
+			{/if}
 		{:else}
 			<button>Crear</button>
 		{/if}
-		<button type="button" class="outline" on:click={() => history.back()}>Cancelar</button>
+		<button
+			type="button"
+			class="outline"
+			on:click={() => goto(routes.groupMovements(data.category.group_id))}>Volver</button
+		>
 	</fieldset>
 </form>

--- a/my-app/src/routes/groups/+page.svelte
+++ b/my-app/src/routes/groups/+page.svelte
@@ -30,7 +30,7 @@
 				<li><a href={routes.groupDetails}>Añadir grupo</a></li>
 				<li><a href={routes.spendingDetails}>Añadir gasto</a></li>
 				<li><a href={routes.budgetDetails}>Añadir presupuesto</a></li>
-				<li><a href={routes.categoryDetails}>Añadir categoría</a></li>
+				<li><a href={routes.categoryDetails()}>Añadir categoría</a></li>
 			</ul>
 		</details>
 	</div>

--- a/my-app/src/routes/groups/[id=integer]/balance/+page.svelte
+++ b/my-app/src/routes/groups/[id=integer]/balance/+page.svelte
@@ -94,9 +94,3 @@
 		</p>
 	</article>
 {/each}
-
-<style>
-	.no-underline {
-		border-bottom: 0px;
-	}
-</style>

--- a/my-app/src/routes/groups/[id=integer]/budgets/+page.svelte
+++ b/my-app/src/routes/groups/[id=integer]/budgets/+page.svelte
@@ -39,10 +39,18 @@
 </article>
 
 {#each filteredBudgets as budget}
+	{@const isReadOnly = data.categories.find((c) => c.id === budget.category_id)?.is_archived}
 	<article>
 		<header class="row jc-space-between">
 			<b>{budget.description}</b>
-			<p>{getCategoryNameById(data.categories, budget.category_id)}</p>
+			<p>
+				{#if isReadOnly}
+					<span class="no-underline" data-tooltip="Archivada">
+						<CssIcon name="lock" />
+					</span>
+				{/if}
+				{getCategoryNameById(data.categories, budget.category_id)}
+			</p>
 		</header>
 		<div class="grid">
 			{formatDateString(budget.start_date)} — {formatDateString(budget.end_date)}
@@ -54,6 +62,7 @@
 					class="secondary outline btn-sm"
 					href="{routes.budgetDetails}/{budget.id}"
 					role="button"
+					disabled={isReadOnly}
 					data-tooltip="Editar"
 				>
 					<CssIcon name="pen" />

--- a/my-app/src/routes/groups/[id=integer]/budgets/+page.svelte
+++ b/my-app/src/routes/groups/[id=integer]/budgets/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import { getCategoryNameById, routes, title } from '$lib';
 	import CategoryFilter from '$lib/components/CategoryFilter.svelte';
 	import CssIcon from '$lib/components/CssIcon.svelte';
@@ -39,7 +40,7 @@
 </article>
 
 {#each filteredBudgets as budget}
-	{@const isReadOnly = data.categories.find((c) => c.id === budget.category_id)?.is_archived}
+	{@const isReadOnly = data.categories.find((c) => c.id === budget.category_id).is_archived}
 	<article>
 		<header class="row jc-space-between">
 			<b>{budget.description}</b>
@@ -58,15 +59,14 @@
 				<p class="t-right" style="margin-left: auto; padding-right:5%">
 					{formatMoney(budget.amount)}
 				</p>
-				<a
+				<button
 					class="secondary outline btn-sm"
-					href="{routes.budgetDetails}/{budget.id}"
-					role="button"
+					on:click={() => goto(`${routes.budgetDetails}/${budget.id}`)}
 					disabled={isReadOnly}
 					data-tooltip="Editar"
 				>
 					<CssIcon name="pen" />
-				</a>
+				</button>
 			</div>
 		</div>
 	</article>

--- a/my-app/src/routes/groups/[id=integer]/categoryBalance/+page.svelte
+++ b/my-app/src/routes/groups/[id=integer]/categoryBalance/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import { title } from '$lib';
+	import { archivedCategoriesLast } from '$lib/balance-utils';
 	import BalanceDisplay from '$lib/components/BalanceDisplay.svelte';
+	import CssIcon from '$lib/components/CssIcon.svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
+	let sortedCategories = archivedCategoriesLast(data.categories);
 </script>
 
 <svelte:head>
@@ -16,12 +19,17 @@
 	</hgroup>
 </header>
 
-{#each data.categories as category}
+{#each sortedCategories as category}
 	{@const spendings = data.spendings.filter((s) => s.category_id === category.id)}
 	{@const budgets = data.budgets.filter((b) => b.category_id === category.id)}
 	<article>
 		<header class="row jc-space-between">
 			<p>
+				{#if category.is_archived}
+					<span class="no-underline" data-tooltip="Archivada">
+						<CssIcon name="lock" />
+					</span>
+				{/if}
 				<b>{category.name}</b> -
 				{category.description}
 			</p>

--- a/my-app/src/routes/groups/[id=integer]/members/+page.svelte
+++ b/my-app/src/routes/groups/[id=integer]/members/+page.svelte
@@ -3,6 +3,7 @@
 	import { confirmLeaveGroup } from '$lib/client/alerts';
 	import Avatar from '$lib/components/Avatar.svelte';
 	import CssIcon from '$lib/components/CssIcon.svelte';
+	import OwnerOnly from '$lib/components/OwnerOnly.svelte';
 	import type { PageData } from './$types';
 
 	export let data: PageData;
@@ -20,10 +21,12 @@
 		<h2>Miembros de {data.group.name}</h2>
 	</hgroup>
 	<div>
-		<a href="{routes.sendInvite}/{data.group.id}" role="button">
-			<CssIcon name="user-add" />
-			Invitar
-		</a>
+		<OwnerOnly ownerId={data.group.owner_id}>
+			<a href="{routes.sendInvite}/{data.group.id}" role="button">
+				<CssIcon name="user-add" />
+				Invitar
+			</a>
+		</OwnerOnly>
 	</div>
 </header>
 

--- a/my-app/src/routes/groups/[id=integer]/movements/+page.svelte
+++ b/my-app/src/routes/groups/[id=integer]/movements/+page.svelte
@@ -62,7 +62,7 @@
 			<ul dir="rtl">
 				<li><a href="{routes.spendingDetails}?groupId={data.group.id}">Añadir gasto</a></li>
 				<li><a href="{routes.budgetDetails}?groupId={data.group.id}">Añadir presupuesto</a></li>
-				<li><a href="{routes.categoryDetails}?groupId={data.group.id}">Añadir categoría</a></li>
+				<li><a href="{routes.categoryDetails()}?groupId={data.group.id}">Añadir categoría</a></li>
 				<li><a href="{routes.paymentDetails}?groupId={data.group.id}">Añadir pago</a></li>
 			</ul>
 		</details>

--- a/my-app/src/routes/spendings/details/[[id=integer]]/+page.svelte
+++ b/my-app/src/routes/spendings/details/[[id=integer]]/+page.svelte
@@ -36,6 +36,7 @@
 			try {
 				const response = await fetch(`${routes.apiCategories}?groupId=${groupId}`);
 				categories = await response.json();
+				categories = categories.filter((category) => !category.is_archived);
 				return;
 			} catch {}
 		}

--- a/my-app/src/types.d.ts
+++ b/my-app/src/types.d.ts
@@ -20,6 +20,7 @@ declare global {
 		group_id: Id;
 		description: string;
 		strategy: string;
+		is_archived: boolean;
 	};
 
 	type Budget = {
@@ -42,13 +43,13 @@ declare global {
 		date: string;
 	};
 
-	interface UniqueSpending extends Spending {}
+	interface UniqueSpending extends Spending { }
 
 	interface InstallmentSpending extends Spending {
 		amount_of_installments: number;
 	}
 
-	interface RecurringSpending extends Spending {}
+	interface RecurringSpending extends Spending { }
 
 	type Payment = {
 		id: Id;
@@ -101,4 +102,4 @@ declare global {
 	};
 }
 
-export {};
+export { };

--- a/my-app/static/styles.css
+++ b/my-app/static/styles.css
@@ -1,6 +1,7 @@
 .mb {
 	margin-bottom: 1em;
 }
+
 .ml {
 	margin-left: 1em;
 }
@@ -21,6 +22,7 @@
 .t-center {
 	text-align: center;
 }
+
 .t-right {
 	text-align: right;
 }
@@ -28,4 +30,8 @@
 .btn-sm {
 	font-size: small;
 	padding: 0.5em;
+}
+
+.no-underline {
+	border-bottom: 0px;
 }


### PR DESCRIPTION
Closes #74

Nuevo botón para archivar categoría:
![image](https://github.com/VaquitApp/frontend/assets/47506558/24021777-a5b6-4f8d-9348-a9943e27ef66)


Editando categoría archivada:
![image](https://github.com/VaquitApp/frontend/assets/47506558/08f632dc-c5e0-4b45-999c-e76fd164827b)

Aparte de eso, los botones de categoría se muestran con contraste si están archivadas, y se ordenan de forma de estar las activas primero. En la vista de `categoryBalances` se muestra un candado sobre categorías archivadas, y se muestran primero todas las activas. En las vistas de creación de gastos y presupuestos se omiten las opciones de categorías archivadas. Además, en la lista de presupuestos no se permite editar presupuestos cuyas categorías estén archivadas.